### PR TITLE
録画再生用エンコードコマンドの調整

### DIFF
--- a/pseudo_quality.py
+++ b/pseudo_quality.py
@@ -316,7 +316,7 @@ def buildHWEncCOptions(
     # フラグ
     ## 主に HWEncC の起動を高速化するための設定
     options.append('-m avioflags:direct -m fflags:nobuffer+flush_packets -m flush_packets:1 -m max_delay:250000')
-    options.append('-m max_interleave_delta:500K --output-thread 0 --lowlatency')
+    options.append('-m max_interleave_delta:500K --lowlatency')
     ## QSVEncC と rkmppenc では OpenCL を使用しないので、無効化することで初期化フェーズを高速化する
     if encoder_type == 'QSVEncC' or encoder_type == 'rkmppenc':
         options.append('--disable-opencl')


### PR DESCRIPTION
録画再生用にエンコードコマンドを調整しました。といっても```--output-thread 0```を削るだけで、これによりエンコード速度が改善します。(qsvencc@N305では240fps→300fps)

```--output-thread 0```はもともとライブ再生時のフレーム間の出力間隔の安定性向上のために入っていたもので、ライブ再生時には必要ですが、録画再生時には必要なく```--output-thread 0```は削ってしまったほうが良さそうでした。

--lowlatencyやそのほかのオプションの変更も試しましたが、起動速度安定のためにはいずれも現状がよさそうです。