### PR TITLE
固定長GOPとするためのエンコードオプションの追加。

### DIFF
--- a/pseudo_quality.py
+++ b/pseudo_quality.py
@@ -372,6 +372,12 @@ def buildHWEncCOptions(
     # gop_length_second = self.GOP_LENGTH_SECOND
     gop_length_second = 2.5
 
+    # GOP長を固定にする
+    if encoder_type == 'QSVEncC':
+        options.append('--strict-gop')
+    elif encoder_type == 'NVEncC':
+        options.append('--no-i-adapt')
+
     # インターレース映像
     # if self.recorded_video.video_scan_type == 'Interlaced':
     if True:


### PR DESCRIPTION
GOP長を固定するためのオプションを追加し、必ず指定のGOP長になるようにします。

もっとも実際にGOP長が可変となりうるのはNVEncでlookaheadを使用した時のみですが、念のための追加です。

その他はこれで問題ないと確認しました。
- ```global_header```は```--repeat-headers```相当
- ```cgop```もhwenc系はデフォルトでclosed GOP
となります。